### PR TITLE
Add BufReadPost to g:quickfixsigns_events, for VCS signs

### DIFF
--- a/doc/quickfixsigns.txt
+++ b/doc/quickfixsigns.txt
@@ -205,7 +205,7 @@ g:quickfixsign_timeout         (default: 0)
     class definitions (see |g:quickfixsigns_classes|).
 
                                                     *g:quickfixsigns_events*
-g:quickfixsigns_events         (default: ['BufEnter', 'CursorHold', 'CursorHoldI', 'InsertLeave', 'InsertEnter'])
+g:quickfixsigns_events         (default: ['BufReadPost', 'BufEnter', 'CursorHold', 'CursorHoldI', 'InsertLeave', 'InsertEnter'])
     List of events for signs that should be frequently updated.
 
                                                     *g:quickfixsigns_class_rel*

--- a/plugin/quickfixsigns.vim
+++ b/plugin/quickfixsigns.vim
@@ -84,7 +84,7 @@ endif
 
 if !exists('g:quickfixsigns_events')
     " List of events for signs that should be frequently updated.
-    let g:quickfixsigns_events = ['BufEnter', 'CursorHold', 'CursorHoldI', 'InsertLeave', 'InsertEnter']   "{{{2
+    let g:quickfixsigns_events = ['BufReadPost', 'BufEnter', 'CursorHold', 'CursorHoldI', 'InsertLeave', 'InsertEnter']   "{{{2
 endif
 
 


### PR DESCRIPTION
Without BufRead*, the VCS signs get not updated after a buffer is being
re-read, e.g. through `:checktime`.