### PR TITLE
Add quickfixsigns#vcsdiff#GetHunkSummary

### DIFF
--- a/autoload/quickfixsigns/vcsdiff.vim
+++ b/autoload/quickfixsigns/vcsdiff.vim
@@ -194,6 +194,24 @@ function! quickfixsigns#vcsdiff#GetList(filename) "{{{3
 endf
 
 
+" Get status of VCS changes as [added, modified, removed].
+function! quickfixsigns#vcsdiff#GetHunkSummary(...) "{{{3
+    let filename = a:0 ? a:1 : expand("%")
+    let list = quickfixsigns#vcsdiff#GetList(filename)
+    let r = [0, 0, 0]  " added, modified, removed.
+    for item in list
+        if item.change == 'ADD'
+            let r[0] += 1
+        elseif item.change == 'CHANGE'
+            let r[1] += 1
+        elseif item.sign == 'DEL'
+            let r[2] += 1
+        endif
+    endfor
+    return r
+endfunction
+
+
 " quickfixsigns#vcsdiff#GuessType() must return the name of a supported 
 " VCS (see |g:quickfixsigns#vcsdiff#vcs|).
 function! quickfixsigns#vcsdiff#GetList0(filename) "{{{3


### PR DESCRIPTION
This provides an API to query the number of added, modified and changed
places.

It is meant to be used by vim-airlines's hunk extension
(https://github.com/bling/vim-airline/blob/master/autoload/airline/extensions/hunks.vim).