### PR TITLE
Use 'silent!' with 'redir' to handle nesting

### DIFF
--- a/autoload/quickfixsigns/breakpoints.vim
+++ b/autoload/quickfixsigns/breakpoints.vim
@@ -58,7 +58,8 @@ endf
 
 
 function! quickfixsigns#breakpoints#Vim() "{{{3
-    redir => bps
+    " Use 'silent!' to protect against unsupported nesting of 'redir'.
+    silent! redir => bps
     silent breaklist
     redir END
     let acc = []

--- a/plugin/quickfixsigns.vim
+++ b/plugin/quickfixsigns.vim
@@ -228,7 +228,8 @@ function! s:Redir(cmd) "{{{3
     let &verbose = 0
     try
         let rv = ''
-        redir => rv
+        " Use 'silent!' to protect against unsupported nesting of 'redir'.
+        silent! redir => rv
         exec 'silent' a:cmd
         redir END
         return exists('rv')? rv : ''


### PR DESCRIPTION
Nested 'redir' is not supported, and quickfixsigns would cause errors
when using other plugins like ArgsAndMore or EnhancedJumps, which are
using 'redir' themselves.

This is the suggested method by Ingo Karkat.

Ref: https://github.com/chrisbra/Recover.vim/blob/master/autoload/recover.vim#L14

Maybe this patch should / can be enhanced to try the function again on e.g. CursorHold, in case it failed e.g. during BufEnter etc?!