### PR TITLE
plugin to mark VCS merge conflicts

### DIFF
--- a/autoload/quickfixsigns/vcsmerge.vim
+++ b/autoload/quickfixsigns/vcsmerge.vim
@@ -1,0 +1,75 @@
+" @Author:      Sergey Vlasov (sergey@vlasov.me)
+" @git:         http://github.com/tomtom/quickfixsigns_vim/
+" @License:     GPL (see http://www.gnu.org/licenses/gpl.txt)
+" @Last Change: 2016-02-11
+" @Revision:    1
+
+if exists('g:quickfixsigns#vcsmerge#loaded')
+    finish
+endif
+let g:quickfixsigns#vcsmerge#loaded = 1
+scriptencoding utf-8
+
+
+if index(g:quickfixsigns_classes, 'vcsmerge') == -1
+    finish
+endif
+
+if !exists('g:quickfixsigns_class_vcsmerge')
+    " VCS merge conflict markers.
+    "
+    " Users have to enable this sign class by adding 'vcsmerge' to
+    " |g:quickfixsigns_classes|.
+    let g:quickfixsigns_class_vcsmerge = {
+                \ 'sign': '*quickfixsigns#vcsmerge#Signs',
+                \ 'get': 'quickfixsigns#vcsmerge#GetList(%s)',
+                \ 'event': ['BufRead', 'BufWritePost']
+                \ }
+endif
+
+function! quickfixsigns#vcsmerge#Signs(item)
+    return 'QFS_VCSMERGE_'. a:item.change
+endf
+
+if !exists('g:quickfixsigns#vcsmerge#regex')
+    let g:quickfixsigns#vcsmerge#regex = {'TOP': '^<<<<<<< \@=', 'MID': '^=======$', 'BOT': '^>>>>>>> \@='}
+endif
+
+if !exists('g:quickfixsigns#vcsmerge#sign')
+    let g:quickfixsigns#vcsmerge#sign = {'TOP': '<<', 'MID': '==', 'BOT': '>>'}
+endif
+
+if index(g:quickfixsigns_signs, 'QFS_VCSMERGE_TOP') == -1
+    exec 'sign define QFS_VCSMERGE_TOP text='.  g:quickfixsigns#vcsmerge#sign.TOP .' texthl=Error'
+endif
+
+if index(g:quickfixsigns_signs, 'QFS_VCSMERGE_MID') == -1
+    exec 'sign define QFS_VCSMERGE_MID text='.  g:quickfixsigns#vcsmerge#sign.MID .' texthl=Error'
+endif
+
+if index(g:quickfixsigns_signs, 'QFS_VCSMERGE_BOT') == -1
+    exec 'sign define QFS_VCSMERGE_BOT text='.  g:quickfixsigns#vcsmerge#sign.BOT .' texthl=Error'
+endif
+
+
+function! quickfixsigns#vcsmerge#GetList(filename)
+    let bufnr = bufnr('%')
+    let signs = []
+    if bufnr != bufnr(a:filename)
+        if g:quickfixsigns_debug
+            throw "QuickFixSigns DEBUG: bufnr mismatch:" a:filename bufnr bufnr(a:filename)
+        endif
+    else
+        let pos = getpos('.')
+        try
+            exec 'silent g/'. g:quickfixsigns#vcsmerge#regex.TOP. '/ call add(signs, {"bufnr": bufnr, "lnum": line("."), "change": "TOP", "text": "Conflict top hunk"})'
+            exec 'silent g/'. g:quickfixsigns#vcsmerge#regex.MID. '/ call add(signs, {"bufnr": bufnr, "lnum": line("."), "change": "MID", "text": "Conflict middle hunk"})'
+            exec 'silent g/'. g:quickfixsigns#vcsmerge#regex.BOT. '/ call add(signs, {"bufnr": bufnr, "lnum": line("."), "change": "BOT", "text": "Conflict bottom hunk"})'
+        finally
+            call setpos('.', pos)
+        endtry
+    endif
+    " TLogVAR signs
+    return signs
+endf
+

--- a/doc/quickfixsigns.txt
+++ b/doc/quickfixsigns.txt
@@ -13,6 +13,8 @@ Display |signs| at interesting lines:
       this requires that you add the following command to |vimrc|: >
         noremap <silent> <leader><c-l> :call quickfixsigns#RelNumbersOnce()<cr>
     - long lines (see |g:quickfixsigns_class_longlines| for details)
+    - VCS merge conflict markers (Users have to enable this sign class by adding 'vcsmerge' to
+        |g:quickfixsigns_classes|).
 <    - etc.
 
 Other lists can be configured via the |g:quickfixsigns_lists| variable.
@@ -148,6 +150,8 @@ Contents~
         quickfixsigns#breakpoints#Vim .................. |quickfixsigns#breakpoints#Vim()|
         g:tinykeymap#map#quickfixsigns#map ............. |g:tinykeymap#map#quickfixsigns#map|
         g:tinykeymap#map#quickfixsigns#options ......... |g:tinykeymap#map#quickfixsigns#options|
+        g:quickfixsigns#vcsmerge#regex ................. |g:quickfixsigns#vcsmerge#regex|
+        g:quickfixsigns#vcsmerge#sign .................. |g:quickfixsigns#vcsmerge#sign|
 
 
 ========================================================================
@@ -520,6 +524,16 @@ g:tinykeymap#map#quickfixsigns#map (default: g:tinykeymap#mapleader .'s')
                                                     *g:tinykeymap#map#quickfixsigns#options*
 g:tinykeymap#map#quickfixsigns#options (default: {...})
 
+========================================================================
+autoload/quickfixsigns/vcsmerge.vim~
+
+                                                    *g:quickfixsigns#vcsmerge#regex*
+g:quickfixsigns#vcsmerge#regex  (default: {'TOP': '^<<<<<<< \@=', 'MID': '^=======$', 'BOT': '^>>>>>>> \@='})
+    Expressions to match conflict hunks.
+
+                                                    *g:quickfixsigns#vcsmerge#sign*
+g:quickfixsigns#vcsmerge#sign (default: {'TOP': '<<', 'MID': '==', 'BOT': '>>'})
+    Signs to mark conflict hunks.
 
 
 vim:tw=78:fo=w2croql:isk=!-~,^*,^|,^":ts=8:ft=help:norl:


### PR DESCRIPTION
This plugin adds signs for merge conflicts produced by VCS like Git.

Screenshot:
![conflict](https://cloud.githubusercontent.com/assets/717109/13004061/c65c49f4-d181-11e5-9cf1-5cb395fdcb87.png)
