### PR TITLE
Fix doc reference for g:quickfixsigns#marks#{buffer,global}

### DIFF
--- a/plugin/quickfixsigns.vim
+++ b/plugin/quickfixsigns.vim
@@ -64,7 +64,8 @@ if !exists('g:quickfixsigns_classes')
     "   loc     ... |location| list
     "   vcsdiff ... mark changed lines (see |quickfixsigns#vcsdiff#GetList()|)
     "   vcsmerge .. merge conflicts produced by VCS like Git
-    "   marks   ... marks |'a|-zA-Z (see also " |g:quickfixsigns_marks|)
+    "   marks   ... marks |'a|-zA-Z (see also |g:quickfixsigns#marks#global| 
+    "               and |g:quickfixsigns#marks#buffer|)
     "
     " The sign classes are defined in g:quickfixsigns_class_{NAME}.
     "


### PR DESCRIPTION
If I remember correctly doc/quickfixsigns.txt gets autogenerated
somehow, so please cherry-pick and do so (or tell me how to do it).