### PR TITLE
QuickfixsignsListBufferSigns: use sign_getplaced

### DIFF
--- a/autoload/quickfixsigns.vim
+++ b/autoload/quickfixsigns.vim
@@ -69,6 +69,7 @@ function! quickfixsigns#AssertUniqueSigns(bufnr, bufsigns) "{{{3
         for bsign in a:bufsigns
             let key = printf("%s|%s", bsign.lnum, bsign.name)
             if has_key(dict, key)
+                " XXX: only usage of "sign.sign"
                 echom ("QuickFixSigns AssertUniqueSigns: duplicate bufnr=". a:bufnr .":") bsign.sign
             else
                 let dict[key] = 1

--- a/plugin/quickfixsigns.vim
+++ b/plugin/quickfixsigns.vim
@@ -849,6 +849,19 @@ function! QuickfixsignsListBufferSigns(bufnr) "{{{3
     if a:bufnr == -1
         return []
     endif
+
+    if exists('*sign_getplaced')
+        let r = []
+        for sign in sign_getplaced(a:bufnr)[0].signs
+            call add(r, {
+                        \ 'lnum': sign.lnum,
+                        \ 'id': sign.id,
+                        \ 'name': sign.name,
+                        \ })
+        endfor
+        return r
+    endif
+
     let signss = s:Redir('sign place buffer='. a:bufnr)
     if exists('signss')
         let signs = split(signss, '\n')


### PR DESCRIPTION
TODO: does not set/have the "sign" attribute (easily), only used with
AssertUniqueSigns, where it could be removed/replaced - maybe only for
the new method / if missing then?!

Fixes https://github.com/tomtom/quickfixsigns_vim/issues/83.