### PR TITLE
Replace `:redir` with `execute()`

### DIFF
--- a/autoload/quickfixsigns/breakpoints.vim
+++ b/autoload/quickfixsigns/breakpoints.vim
@@ -58,9 +58,13 @@ endf
 
 
 function! quickfixsigns#breakpoints#Vim() "{{{3
-    redir => bps
-    silent breaklist
-    redir END
+    if exists('*execute')
+        let bps = execute('breaklist', 'silent')
+    else
+        redir => bps
+        silent breaklist
+        redir END
+    endif
     let acc = []
     for line in split(bps, '\n')
         let ml = matchlist(line, '^\s*\(\d\+\)\s\+\w\+\s\+\(.\{-}\)\s\+\w\+\s\+\(\d\+\)$')

--- a/plugin/quickfixsigns.vim
+++ b/plugin/quickfixsigns.vim
@@ -267,10 +267,14 @@ function! s:Redir(cmd) "{{{3
     let verbose = &verbose
     let &verbose = 0
     try
-        let rv = ''
-        redir => rv
-        exec 'silent' a:cmd
-        redir END
+        if exists('*execute')
+            let rv = execute(a:cmd, 'silent')
+        else
+            let rv = ''
+            redir => rv
+            exec 'silent' a:cmd
+            redir END
+        endif
         return exists('rv')? rv : ''
     finally
         let &verbose = verbose


### PR DESCRIPTION
This patch avoids the prolem: "Vim(redir):E930: Cannot use :redir inside execute()".

For example, when 'quickfixsign' is used with 'coc.nvim' (the latest version used Vim9 scripts), when `<Plug>(coc-definition)` action is applied to an identifier, and vim switches to the buffer and line where the identifier is defined, `s:Redir()` may be called inside `coc#compat#execute()`, and cause the error.

gVim ver 9.1-1508
[vim.log](https://github.com/user-attachments/files/21077788/vim.log)
